### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Compile documentation
         run: |
           java -jar widoco.jar \
-          -ontFile cop.owl \
+          -ontFile cop.ttl \
           -outFolder output \
           -includeAnnotationProperties \
           -rewriteAll \


### PR DESCRIPTION
Update the extension of the ontology file that is used for generating the documentation from `.owl` to `.ttl`